### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/examples/heartbeat.js
+++ b/examples/heartbeat.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var config = require( __dirname + '/../config.json' ),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     channel = '/heartbeat',
     MessageHub = require( __dirname + '/../index' ),
     casual = require('casual'),

--- a/examples/producer.js
+++ b/examples/producer.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var config = require( __dirname + '/../config.json' ),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     channel = config.channels[ 0 ],
     MessageHub = require( __dirname + '/../index' ),
     casual = require('casual'),

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "faye": "^1.1.2",
     "lodash": "^4.5.0",
     "moment": "^2.12.0",
-    "node-uuid": "^1.4.7",
-    "simple-node-logger": "^0.93.11"
+    "simple-node-logger": "^0.93.11",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "casual": "^1.5.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.